### PR TITLE
fix!: remove invoker and installer jsx/npm attributes

### DIFF
--- a/src/main/jsx-scope-attributes.ts
+++ b/src/main/jsx-scope-attributes.ts
@@ -17,12 +17,5 @@ export const JsxScopeAttributes = Object.freeze({
   MODULE_SPECIFIER: 'jsx.element.module.specifier',
   ATTRIBUTE_NAMES: 'jsx.element.attributes.names',
   ATTRIBUTE_VALUES: 'jsx.element.attributes.values',
-  ATTRIBUTE_MAP: 'jsx.element.attributes.map',
-
-  //
-  // Attributes relating to a jsx element's invoker
-  //
-  INVOKER_PACKAGE_RAW: 'jsx.element.invoker.package.raw',
-  INVOKER_PACKAGE_NAME: 'jsx.element.invoker.package.name',
-  INVOKER_PACKAGE_OWNER: 'jsx.element.invoker.package.owner'
+  ATTRIBUTE_MAP: 'jsx.element.attributes.map'
 })

--- a/src/main/npm-scope-attributes.ts
+++ b/src/main/npm-scope-attributes.ts
@@ -37,17 +37,5 @@ export const NpmScopeAttributes = Object.freeze({
   VERSION_MAJOR: 'npm.dependency.version.major',
   VERSION_MINOR: 'npm.dependency.version.minor',
   VERSION_PATCH: 'npm.dependency.version.patch',
-  VERSION_PRE_RELEASE: 'npm.dependency.version.preRelease',
-
-  //
-  // Attributes relating to a dependency's installer
-  //
-  INSTALLER_RAW: 'npm.dependency.installer.raw',
-  INSTALLER_OWNER: 'npm.dependency.installer.owner',
-  INSTALLER_NAME: 'npm.dependency.installer.name',
-  INSTALLER_VERSION_RAW: 'npm.dependency.installer.version.raw',
-  INSTALLER_VERSION_MAJOR: 'npm.dependency.installer.version.major',
-  INSTALLER_VERSION_MINOR: 'npm.dependency.installer.version.minor',
-  INSTALLER_VERSION_PATCH: 'npm.dependency.installer.version.patch',
-  INSTALLER_VERSION_PRE_RELEASE: 'npm.dependency.installer.version.preRelease'
+  VERSION_PRE_RELEASE: 'npm.dependency.version.preRelease'
 })


### PR DESCRIPTION
Closes #8 

removes jsx's `INVOKER.xxx` and npm's `INSTALLER.xxx` attributes 

#### Changelog

**Removed**

- removes jsx's `INVOKER.xxx` attributes as per specified in #8 
- removes npm's `INSTALLER.xxx` attributes as a cleanup step, previously deprected in https://github.com/ibm-telemetry/telemetry-js/pull/169/files#diff-d446e667ea1df8d1b76f11859c9f9ef2a1cafe71968100b330c27c2013f980feL75-L82

#### Testing / reviewing
 
N/A
