### PR TITLE
fix: correct js scope attr object name

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,5 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 export * from './custom-resource-attributes.js'
+export * from './js-scope-attributes.js'
 export * from './jsx-scope-attributes.js'
 export * from './npm-scope-attributes.js'

--- a/src/main/js-scope-attributes.ts
+++ b/src/main/js-scope-attributes.ts
@@ -4,7 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-export const JsxScopeAttributes = Object.freeze({
+export const JsScopeAttributes = Object.freeze({
   //
   // JS scope metrics
   //


### PR DESCRIPTION
#### Changelog


**Changed**

- Change Js scope attributes object name from `JsxScopeAttributes` to `JsScopeAttributes`

#### Testing / reviewing

N/A