### PR TITLE
fix: correct js scope function argument attr name

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,5 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 export * from './custom-resource-attributes.js'
+export * from './js-scope-attributes.js'
 export * from './jsx-scope-attributes.js'
 export * from './npm-scope-attributes.js'

--- a/src/main/js-scope-attributes.ts
+++ b/src/main/js-scope-attributes.ts
@@ -22,5 +22,5 @@ export const JsScopeAttributes = Object.freeze({
   //
   FUNCTION_NAME: 'js.function.name',
   FUNCTION_ACCESS_PATH: 'js.function.accessPath',
-  FUNCTION_ARGUMENT_VALUESt: 'js.function.arguments.values'
+  FUNCTION_ARGUMENT_VALUES: 'js.function.arguments.values'
 })

--- a/src/main/js-scope-attributes.ts
+++ b/src/main/js-scope-attributes.ts
@@ -4,7 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-export const JsxScopeAttributes = Object.freeze({
+export const JsScopeAttributes = Object.freeze({
   //
   // JS scope metrics
   //


### PR DESCRIPTION
#### Changelog

**Changed**

- Rename Js scope function argument values attribute from `FUNCTION_ARGUMENT_VALUESt` -> `FUNCTION_ARGUMENT_VALUES`

#### Testing / reviewing

N/A