### PR TITLE
fix: add environment name to metrics

### DIFF
--- a/src/main/custom-resource-attributes.ts
+++ b/src/main/custom-resource-attributes.ts
@@ -12,10 +12,20 @@ export const CustomResourceAttributes = Object.freeze({
   DATE: 'date',
 
   //
+  // Attributes related to details about where the emitter is running
+  //
+  ENVIRONMENT_NAME: 'environment.name',
+
+  //
   // Attributes relating to details about the currently-running emitter
   //
   TELEMETRY_EMITTER_NAME: 'telemetry.emitter.name',
   TELEMETRY_EMITTER_VERSION: 'telemetry.emitter.version',
+
+  //
+  // Attribute related to the current scan ID
+  //
+  SCAN_ID: 'scan.id',
 
   //
   // Attributes relating to details about the analyzed repository

--- a/src/main/logs-attributes.ts
+++ b/src/main/logs-attributes.ts
@@ -35,6 +35,11 @@ export const LogsAttributes = Object.freeze({
   ANALYZED_REFS: 'analyzed.refs',
 
   //
+  // Attribute related to the current scan ID
+  //
+  SCAN_ID: 'scan.id',
+
+  //
   // Attributes related to the results of the scan
   //
   RESULTS_IS_COMPLETED: 'results.isCompleted',


### PR DESCRIPTION
Related to https://github.com/ibm-telemetry/telemetry-internal/issues/244
(should not close with this PR)

#### Changelog

**New**

- added `environment.name` and `scan.id` to metric documents attributes
- added `scan.id` to log documents attributes

#### Testing / reviewing
N/A
