### PR TITLE
chore: update copyright notices for telemetry-attributes-js

### DIFF
--- a/.commitlintrc.cjs
+++ b/.commitlintrc.cjs
@@ -1,11 +1,5 @@
 /*
- * Copyright IBM Corp. 2024, 2024
- *
- * This source code is licensed under the Apache-2.0 license found in the
- * LICENSE file in the root directory of this source tree.
- */
-/*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.copyright.js
+++ b/.copyright.js
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. <%= YEAR %>, 2024
+ * Copyright IBM Corp. <%= YEAR %>, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -136,7 +136,7 @@ module.exports = {
     ],
     'n/shebang': 'off',
     'notice/notice': [
-      'warn',
+      'error',
       {
         templateFile: path.join(__dirname, '.copyright.js')
       }

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/scripts/format-package-json.js
+++ b/scripts/format-package-json.js
@@ -1,11 +1,11 @@
 /*
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/main/custom-resource-attributes.ts
+++ b/src/main/custom-resource-attributes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/main/js-scope-attributes.ts
+++ b/src/main/js-scope-attributes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2024, 2024
+ * Copyright IBM Corp. 2024, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/main/jsx-scope-attributes.ts
+++ b/src/main/jsx-scope-attributes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/main/logs-attributes.ts
+++ b/src/main/logs-attributes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2025, 2024
+ * Copyright IBM Corp. 2025, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/src/main/npm-scope-attributes.ts
+++ b/src/main/npm-scope-attributes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2023, 2024
+ * Copyright IBM Corp. 2023, 2025
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Closes ibm-telemetry/telemetry-internal#287

#### Changelog

**Changed**
- eslint copyright notice rule changed from warning to error
- updated notice template to current year 2025
- updated current year to 2025 in all existing source file notices

#### Testing / reviewing

- all source file notices should be properly updated
- newly created files should have proper notice added when `npm run lint:fix` runs